### PR TITLE
Python comments started with line-break will not be removed

### DIFF
--- a/ramile/filters/comment_block_filter.py
+++ b/ramile/filters/comment_block_filter.py
@@ -12,12 +12,12 @@ class CommentBlockFilterBase(LineFilterBase):
                 file.mark_comment_block_end()
             return line, True
         else:
-            is_comment_block, comment_block_end_sign = self.is_comment_block(line)
+            is_comment_block, comment_block_start_sign, comment_block_end_sign = self.is_comment_block(line)
             if is_comment_block:
                 file.mark_comment_block_start(comment_block_end_sign)
                 file.found_comment_line()
-
-                if self.close_comment_block(file, line):
+                line_tail = line[len(comment_block_start_sign):]
+                if self.close_comment_block(file, line_tail):
                     file.mark_comment_block_end()
                 return line, True
         return line, False
@@ -31,8 +31,8 @@ class CommentBlockFilterBase(LineFilterBase):
         """
         for sign_start in self.block_signs.keys():
             if line.startswith(sign_start):
-                return True, self.block_signs[sign_start]
-        return False, None
+                return True, sign_start, self.block_signs[sign_start]
+        return False, None, None
 
     def close_comment_block(self, file, line):
         return line.endswith(file.comment_block_end_sign)

--- a/tests/data/python_module/settings.py
+++ b/tests/data/python_module/settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+"""
+    Some Script
+    ~~~~~~~~
+
+    :copyright: (c) 2020 by Somebody <somebody@iamhd.top>
+"""
+
+import os
+
+if __name__ == "__main__":
+    '''do something'''
+    pass

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -18,7 +18,7 @@ Python                       1              4            14                6
     assert project.info.lines_skipped_comments == 14
     return
 
-def test_file__init__():
+def test_comments_startswith_linebreak():
     """ Test with python_module/settings.py:
 -------------------------------------------------------------------------------
 Language                     files          blank        comment           code

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -17,3 +17,20 @@ Python                       1              4            14                6
     assert project.info.lines_skipped_blank == 4
     assert project.info.lines_skipped_comments == 14
     return
+
+def test_file__init__():
+    """ Test with python_module/settings.py:
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Python                           1              4              7              3
+-------------------------------------------------------------------------------
+    """
+    project = Project('data/python_module',
+                      3000, 'test-output.docx')
+    project.run()
+    assert project.info.lines_extracted == 3
+    assert project.info.lines_skipped_blank == 4
+    assert project.info.lines_skipped_comments == 7
+
+    return


### PR DESCRIPTION
# Problem

Comments started with line-break will not be removed.

# Input
```python
# -*- coding: utf-8 -*-

"""
    Some Script
    ~~~~~~~~
    :copyright: (c) 2020 by Somebody <somebody@iamhd.top>
"""

import os

if __name__ == "__main__":
    '''do something'''
    pass
```

# Expected output

```text
import os
if __name__ == "__main__":
    pass
```

# Actual output
```text
    Some Script
    ~~~~~~~~
    :copyright: (c) 2020 by Somebody <somebody@iamhd.top>
import os
if __name__ == "__main__":
    pass
```

# Fix

See committed src and test.
